### PR TITLE
Update JWKSet: pass JWK key when 'use' parameter is absent

### DIFF
--- a/src/common/java/org/bsworks/catalina/authenticator/oidc/JWKSet.java
+++ b/src/common/java/org/bsworks/catalina/authenticator/oidc/JWKSet.java
@@ -54,7 +54,7 @@ class JWKSet {
 			for (int n = keysProp.length() - 1; n >= 0; n--) {
 				final JSONObject keyDef = keysProp.getJSONObject(n);
 				if (keyDef.optString("kty").equals("RSA")
-						&& keyDef.optString("use").equals("sig"))
+						&& keyDef.optString("use", "sig").equals("sig"))
 					this.keys.put(keyDef.getString("kid"),
 							keyFactory.generatePublic(new RSAPublicKeySpec(
 									new BigInteger(1, base64.decode(


### PR DESCRIPTION
The JWK returned from my IdP doesn't contain a 'use' parameter, see https://aai-dev.egi.eu/oidc/jwk: 

`{"keys": [ {"kty": "RSA", "e": "AQAB", "kid": "oidc", "alg": "RS256", "n": "<long string>" } ] }`

Because of this, the authenticator failed to verify the signature of the JWT. 

I'm by no means an expert but according to https://tools.ietf.org/html/rfc7517#section-4.2, the 'use' parameter is optional. 
So I assume that the JWK key can be used for anything when 'use' is absent.